### PR TITLE
Faster target generation, better compositing

### DIFF
--- a/objdetect/generate_training.py
+++ b/objdetect/generate_training.py
@@ -51,15 +51,25 @@ def affine_transform(img, rotation, scale):
 
 # Reduce image quality and add lighting effects and noise to give targets the feeling of having been photographed
 def add_noise(img, args):
-    img = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
-    for row in range(img.shape[0]):
-        for col in range(img.shape[1]):
-            # Desaturate
-            img[row, col, 1] *= args.lighting_constant
-            # Add a noise value to each of a pixel's saturation, and value
-            for i in [1, 2]:
-                value = img[row, col, i]
-                img[row, col, i] += min(255 - value, max(-int(value), random.randint(-args.noise_intensity, args.noise_intensity)))
+    origtype = img.dtype
+    img = cv2.cvtColor(img, cv2.COLOR_BGR2HSV).astype(float)
+    img[:,:,1] *= args.lighting_constant
+
+    hue_noise = np.zeros(img.shape[:2])
+    sat_noise = np.random.uniform(-args.noise_intensity, args.noise_intensity, img.shape[:2])
+    val_noise = np.random.uniform(-args.noise_intensity, args.noise_intensity, img.shape[:2])
+    img = cv2.add(img, cv2.merge([hue_noise, sat_noise, val_noise]))
+
+    # for row in range(img.shape[0]):
+    #     for col in range(img.shape[1]):
+    #         # Desaturate
+    #         img[row, col, 1] *= args.lighting_constant
+    #         # Add a noise value to each of a pixel's saturation, and value
+    #         for i in [1, 2]:
+    #             value = img[row, col, i]
+    #             img[row, col, i] += min(255 - value, max(-int(value), random.randint(-args.noise_intensity, args.noise_intensity)))
+    img = np.clip(img, 0, 255)
+    img = img.astype(origtype)
     img = cv2.cvtColor(img, cv2.COLOR_HSV2BGR)
     return img
 


### PR DESCRIPTION
A few changes here aiming at simplicity, efficiency, and making the target edges look a little better.

1. The affine transformation is performed in one pass rather than two (simpler)
2. Noise addition is performed by adding numpy arrays instead of python loops (faster)
3. Alpha blending performs the arithmetic using numpy and supports semi-transparent pixels

A side effect of (3) is that field images are loaded as the float data type instead of ints because the alpha blending function requires them to be floats.

The only main performance blocker now is (1) the imwrite when we save each training image and (2) the copying of each field-image to a new canvas. Both of these would be solved by decreasing the resolutions of our training images but that's not a big problem for now. We could also save the images as jpgs (the main bottleneck of imwrite is disk speed not cpu), but it's unclear if darknet will support jpgs for training the YOLO network.

Current flame graph:

![Screenshot from 2020-03-15 17-54-00](https://user-images.githubusercontent.com/18223213/76714728-12ac1480-66e6-11ea-93b4-63cdaf430867.png)
